### PR TITLE
fix golangci-lint extract_dir

### DIFF
--- a/bucket/golangci-lint.json
+++ b/bucket/golangci-lint.json
@@ -6,10 +6,12 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/golangci/golangci-lint/releases/download/v1.42.1/golangci-lint-1.42.1-windows-amd64.zip",
+            "extract_dir": "golangci-lint-1.42.1-windows-amd64",
             "hash": "607d68f0960e3a7b69c73bc0164710dabb4ece06c509afa3584b475194e8d720"
         },
         "32bit": {
             "url": "https://github.com/golangci/golangci-lint/releases/download/v1.42.1/golangci-lint-1.42.1-windows-386.zip",
+            "extract_dir": "golangci-lint-1.42.1-windows-386",
             "hash": "e64962d2c3c86caed93f60d7fa33e3f1c7452f3feb44b2d2a3fb6204ed1cddf0"
         }
     },
@@ -20,10 +22,12 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/golangci/golangci-lint/releases/download/v$version/golangci-lint-$version-windows-amd64.zip"
+                "url": "https://github.com/golangci/golangci-lint/releases/download/v$version/golangci-lint-$version-windows-amd64.zip",
+                "extract_dir": "golangci-lint-$version-windows-amd64"
             },
             "32bit": {
-                "url": "https://github.com/golangci/golangci-lint/releases/download/v$version/golangci-lint-$version-windows-386.zip"
+                "url": "https://github.com/golangci/golangci-lint/releases/download/v$version/golangci-lint-$version-windows-386.zip",
+                "extract_dir": "golangci-lint-$version-windows-386"
             }
         },
         "hash": {

--- a/bucket/golangci-lint.json
+++ b/bucket/golangci-lint.json
@@ -22,12 +22,12 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/golangci/golangci-lint/releases/download/v$version/golangci-lint-$version-windows-amd64.zip",
-                "extract_dir": "golangci-lint-$version-windows-amd64"
+                "extract_dir": "golangci-lint-$version-windows-amd64",
+                "url": "https://github.com/golangci/golangci-lint/releases/download/v$version/golangci-lint-$version-windows-amd64.zip"
             },
             "32bit": {
-                "url": "https://github.com/golangci/golangci-lint/releases/download/v$version/golangci-lint-$version-windows-386.zip",
-                "extract_dir": "golangci-lint-$version-windows-386"
+                "extract_dir": "golangci-lint-$version-windows-386",
+                "url": "https://github.com/golangci/golangci-lint/releases/download/v$version/golangci-lint-$version-windows-386.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
golangci-lint 的压缩包是一个文件夹