### PR TITLE
fix `g` hash

### DIFF
--- a/bucket/g.json
+++ b/bucket/g.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/voidint/g/releases/download/v1.5.2/g1.5.2.windows-amd64.zip",
-            "hash": "9ece91426b96b8e3358c4096c3fe5fda38d3494cb5caa417e2e88bfade82db2b"
+            "hash": "97546632cf18914f4da1b3318b4bb41eb15b49c5826802352776d705321d04d9"
         },
         "32bit": {
             "url": "https://github.com/voidint/g/releases/download/v1.5.2/g1.5.2.windows-386.zip",


### PR DESCRIPTION
作者在16小时之前重新上传了releases文件，导致19小时之前更新的hash不匹配