### PR TITLE
Update hash for 64bit architecture in g.json

### DIFF
--- a/bucket/g.json
+++ b/bucket/g.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/voidint/g/releases/download/v1.8.0/g1.8.0.windows-amd64.zip",
-            "hash": "27c7d914a3bbf6e80059a1104f1c4c4dda7eb503547a8c5597d233c544cbd5d5"
+            "hash": "93ad318012c8dc601b93ad44ce82b10fbdb23e169d831bb041061c0f6783c7e9"
         },
         "32bit": {
             "url": "https://github.com/voidint/g/releases/download/v1.8.0/g1.8.0.windows-386.zip",


### PR DESCRIPTION
I think they build release assets again so the checksum changed